### PR TITLE
DATA: Updating V4 Lite and 20,000 evidence files for November 2024

### DIFF
--- a/20000 Evidence Records.yml
+++ b/20000 Evidence Records.yml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9fffb1520ad0fdee1132954956dad9ecfd41e90cb625b1ca7033529179680dfe
-size 4411190
+oid sha256:1ad09cf16da1cc3952592cce4c48777e5759d56858d97f3c469de1f8d7f3cb8e
+size 4250429

--- a/51Degrees-LiteV4.1.hash
+++ b/51Degrees-LiteV4.1.hash
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4fb5aa950dce0f9314ddd1c41da76e95565c2c3a1280f8c53832cb4060ea2c6f
-size 73539000
+oid sha256:8996e85aebbdabd7190f5680b5eceb86781323568617b45f07341cc186bd000e
+size 73739873


### PR DESCRIPTION
Updating device detection data with 20241104 files for V4 lite and 20,000 evidence.