### PR TITLE
remove common-ci submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,1 @@
-[submodule "ci/common-ci"]
-	path = ci/common-ci
-	url = ../common-ci
+


### PR DESCRIPTION
Looks like these commits (removing `common-ci` submodule) made sense as device-detection-data is not building itself, so not sure why it needs `common-ci`