### PR TITLE
Add UTM parameters to 51degrees.com links

### DIFF
--- a/.github/workflows/utm-link-lint.yml
+++ b/.github/workflows/utm-link-lint.yml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a16ba3200660b54152c5306e469d3e287fda3b315e67fe1fe433e7008d38347
+size 513

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![51Degrees](https://51degrees.com/DesktopModules/FiftyOne/Distributor/Logo.ashx?utm_source=github&utm_medium=repository&utm_content=home&utm_campaign=c-open-source "Data rewards the curious") **Device Detection Data Files**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=device-detection-data&utm_content=readme.md&utm_term=top "Data rewards the curious") **Device Detection Data Files**
 
 # Introduction
 
@@ -19,7 +19,7 @@ The properties available in this file are:
 - SetHeaderPlatformAccept-CH
 - JavascriptGetHighEntropyValues
 - JavascriptHardwareProfile
-- More properties are available for free in our [cloud service](https://configure.51degrees.com/), or on a commercial basis on [our website](https://51degrees.com/pricing).
+- More properties are available for free in our [cloud service](https://configure.51degrees.com/?utm_source=github&utm_medium=readme&utm_campaign=device-detection-data&utm_content=readme.md&utm_term=introduction), or on a commercial basis on [our website](https://51degrees.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=device-detection-data&utm_content=readme.md&utm_term=introduction).
 
 This 'lite' file is built from a subsection of all devices and is updated less frequently than the paid-for data files.
 

--- a/metrics/README.txt
+++ b/metrics/README.txt
@@ -1,1 +1,1 @@
-## Metrics contains the assets for https://51degrees.com/device-data-quality and is updated weekly.
+## Metrics contains the assets for https://51degrees.com/device-data-quality?utm_source=github&utm_medium=readme&utm_campaign=device-detection-data&utm_content=metrics-readme.txt&utm_term=top and is updated weekly.


### PR DESCRIPTION
Add UTM parameters to navigational 51degrees.com and configure.51degrees.com links so the Content Team can trace traffic to its exact source.

- README.md: replaced the legacy Logo.ashx logo URL with the img/logo.png scheme, tagged the configure.51degrees.com cloud-service link and the 51degrees.com/pricing link.
- metrics/README.txt: tagged the 51degrees.com/device-data-quality navigational link.

Adds the UTM link lint workflow in a separate commit.

Functional/data-download hosts and the Azure DevOps CI reference were left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)